### PR TITLE
Only typecheck immediate sources, not transitive

### DIFF
--- a/templates/mypy.sh.tpl
+++ b/templates/mypy.sh.tpl
@@ -27,7 +27,7 @@ main() {
   fi
 
   set +o errexit
-  output=$($mypy {VERBOSE_OPT} --bazel --package-root . --config-file {MYPY_INI_PATH} --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1)
+  output=$({MYPY_EXE} {VERBOSE_OPT} --bazel {SRC_ROOTS} --config-file {MYPY_INI_PATH} --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1)
   status=$?
   set -o errexit
 


### PR DESCRIPTION
Hi @thundergolfer,

I found this repository after reading https://github.com/python/mypy/issues/3912#issuecomment-580023391 and I'm also interested in typechecking Bazel-built Python code. I think I've run into a similar issue as @dmadisetti (with generated protobuf code), but I have a question and/or a different approach than #11.

If I understand Bazel aspects correctly (I'm not an expert), if I have `py_library` targets `//py:b` which depends on `//py:a`, and I build `//py:b`, Bazel will invoke the mypy aspect for both, so it's not necessary to check `:a`'s sources while checking `:b`s. This PR modifies the mypy aspect to do that. I tested in an internal codebase and found that typecheck errors were still caught in transitive dependencies with this change.

This PR is incomplete because it breaks `mypy_test`, but if this approach seems reasonable to you, I'll go ahead and fix it so it's mergeable.

Thanks.