### PR TITLE
allow setting extra pip args in repositories/deps.bzl

### DIFF
--- a/repositories/deps.bzl
+++ b/repositories/deps.bzl
@@ -6,7 +6,7 @@ repository.
 
 load(":py_repositories.bzl", "py_deps")
 
-def deps(mypy_requirements_file, python_interpreter=None, python_interpreter_target=None):
+def deps(mypy_requirements_file, python_interpreter=None, python_interpreter_target=None, extra_pip_args=None):
     """Pull in external dependencies needed by rules in this repo.
     Pull in all dependencies needed to run rules in this
     repository.
@@ -15,4 +15,4 @@ def deps(mypy_requirements_file, python_interpreter=None, python_interpreter_tar
     'repositories' in //repositories:repositories.bzl have been imported
     already.
     """
-    py_deps(mypy_requirements_file, python_interpreter, python_interpreter_target)
+    py_deps(mypy_requirements_file, python_interpreter, python_interpreter_target, extra_pip_args)

--- a/repositories/py_repositories.bzl
+++ b/repositories/py_repositories.bzl
@@ -5,7 +5,7 @@ Provides functions to pull the external Mypy package dependency.
 
 load("@rules_python//python:pip.bzl", "pip_install")
 
-def py_deps(mypy_requirements_file, python_interpreter, python_interpreter_target):
+def py_deps(mypy_requirements_file, python_interpreter, python_interpreter_target, extra_pip_args):
     """Pull in external Python packages needed by py binaries in this repo.
     Pull in all dependencies needed to build the Py binaries in this
     repository. This function assumes the repositories imported by the macro
@@ -20,4 +20,5 @@ def py_deps(mypy_requirements_file, python_interpreter, python_interpreter_targe
             requirements = mypy_requirements_file,
             python_interpreter = python_interpreter or "python3",  # mypy requires Python3
             python_interpreter_target = python_interpreter_target,
+            extra_pip_args = extra_pip_args,
         )


### PR DESCRIPTION
one specific use case is to set a custom ca bundle for pip downloads.

---

i need a custom CA bundle to build behind a corperate network.