### PR TITLE
chore: remove examples/.bazelrc

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,2 +1,0 @@
-build --aspects //tools/linting:aspect.bzl%lint
-build --output_groups=+report


### PR DESCRIPTION
This setup the linting-system, however the lint.sh script next to it does the same.
It should be possible to build&test the examples without having 'black' on the PATH, for example.