### PR TITLE
Replace `mypy_integration_config` repo with label flag

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,2 @@
+# https://mypy.readthedocs.io/en/stable/config_file.html
+[mypy]

--- a/BUILD
+++ b/BUILD
@@ -19,4 +19,11 @@ licenses(["notice"])  # MIT
 exports_files([
     "LICENSE",
     "version.bzl",
+    ".mypy.ini",
 ])
+
+label_flag(
+    name = "mypy_config",
+    build_setting_default = "//:.mypy.ini",
+    visibility = ["//visibility:public"],
+)

--- a/README.md
+++ b/README.md
@@ -124,16 +124,14 @@ mypy_test(
 ### Configuration
 
 To support the [MyPy configuration file](https://mypy.readthedocs.io/en/latest/config_file.html) you can add the
-following to your `WORKSPACE`:
+following to your `.bazelrc`:
 
-```
-load("@mypy_integration//:config.bzl", "mypy_configuration")
-
-mypy_configuration("//tools/typing:mypy.ini")
+```text
+build --@mypy_integration//:mypy_config=//:mypy.ini
 ```
 
-where `//tools/typing:mypy.ini` is a [valid MyPy config file](https://mypy.readthedocs.io/en/latest/config_file.html#config-file-format).
-
+where `//:mypy.ini` is a [valid MyPy config file](https://mypy.readthedocs.io/en/latest/config_file.html#config-file-format)
+within your projects workspace.
 
 ## 🛠 Development
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,10 +8,6 @@ load(
 
 mypy_integration_repositories()
 
-load("//:config.bzl", "mypy_configuration")
-
-mypy_configuration()
-
 load("//repositories:deps.bzl", mypy_integration_deps = "deps")
 
 mypy_integration_deps("//:current_mypy_version.txt")

--- a/config.bzl
+++ b/config.bzl
@@ -32,6 +32,11 @@ create_config = repository_rule(
 )
 
 def mypy_configuration(mypy_config_file = None):
+    """**Deprecated**: Instead, see https://github.com/bazel-contrib/bazel-mypy-integration/blob/main/README.md#configuration
+
+    Args:
+        mypy_config_file (Label, optional): The label of a mypy configuration file
+    """
     create_config(
         name = "mypy_integration_config",
         config_filepath = mypy_config_file,

--- a/mypy.bzl
+++ b/mypy.bzl
@@ -29,7 +29,7 @@ DEFAULT_ATTRS = {
         cfg = "host",
     ),
     "_mypy_config": attr.label(
-        default = Label("@mypy_integration_config//:mypy.ini"),
+        default = Label("//:mypy_config"),
         allow_single_file = True,
     ),
 }


### PR DESCRIPTION
Currently the `mypy.ini` config file is determined via a repository. This can lead to issues where one repository does not define this or two repositories attempt to create it using different config files. Instead of having users add the following in their workspace
```starlark
load("//:config.bzl", "mypy_configuration")

mypy_configuration()
```
This PR has them update their `.bazelrc` files to pass a build flag which defines what config to use
```
build --@mypy_integration//:mypy_config=//:mypy.ini
```
In this case, a `mypy.ini` in the root of the current workspace would be used as the [mypy config](https://mypy.readthedocs.io/en/latest/config_file.html).