### PR TITLE
Move buildifier targets to //tools/buildifier

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,18 +1,4 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
-
 package(default_visibility = ["//visibility:private"])
-
-buildifier(
-    name = "buildifier.check",
-    lint_mode = "warn",
-    mode = "diff",
-)
-
-buildifier(
-    name = "buildifier",
-    lint_mode = "fix",
-    mode = "fix",
-)
 
 licenses(["notice"])  # MIT
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,9 +46,3 @@ http_archive(
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
-)

--- a/tools/buildifier/BUILD
+++ b/tools/buildifier/BUILD
@@ -1,0 +1,13 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier.check",
+    lint_mode = "warn",
+    mode = "diff",
+)
+
+buildifier(
+    name = "buildifier",
+    lint_mode = "fix",
+    mode = "fix",
+)

--- a/tools/buildifier/BUILD
+++ b/tools/buildifier/BUILD
@@ -1,5 +1,7 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
+package(default_visibility = ["//visibility:private"])
+
 buildifier(
     name = "buildifier.check",
     lint_mode = "warn",


### PR DESCRIPTION
## Problem

`buildifier-prebuilt` is not installed as part of `mypy_integration_repositories` invocation in the WORKSPACE. Therefore downstream projects that depends on bazel-mypy-integration (which then loads `@mypy_integration//:mypy_config` that has `buildifier` targets) will error out with

> Repository '@buildifier _prebuilt' is not defined

## Solution

Move all `buildifier` targets to an isolated location `//tools/buildifier` that downstream projects do not access.

Fixes #64 