### PR TITLE
Support newer mypy versions

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1,6 +1,7 @@
 
 
 import sys
+from typing import Tuple
 from mypy.main import main
 from mypy.version import __version__
 
@@ -8,7 +9,7 @@ from mypy.version import __version__
 # - Release versions have the form "0.NNN".
 # - Dev versions have the form "0.NNN+dev" (PLUS sign to conform to PEP 440).
 # - For 1.0 we'll switch back to 1.2.3 form.
-def version_tuple(v: str) -> tuple[int, ...]:
+def version_tuple(v: str) -> Tuple[int, ...]:
     """Silly method of creating a comparable version object"""
     return tuple(map(int, (v.split("+")[0].split("."))))
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -2,6 +2,20 @@
 
 import sys
 from mypy.main import main
+from mypy.version import __version__
+
+# According to https://github.com/python/mypy/blob/v0.971/mypy/version.py
+# - Release versions have the form "0.NNN".
+# - Dev versions have the form "0.NNN+dev" (PLUS sign to conform to PEP 440).
+# - For 1.0 we'll switch back to 1.2.3 form.
+def version_tuple(v: str) -> tuple[int, ...]:
+    """Silly method of creating a comparable version object"""
+    return tuple(map(int, (v.split("+")[0].split("."))))
 
 if __name__ == '__main__':
-    main(None, sys.stdout, sys.stderr)
+    # 0.981 began requiring keyword arguments
+    if version_tuple(__version__) < (0, 981):
+        main(None, sys.stdout, sys.stderr)
+    else:
+        # The first arg was removed
+        main(stdout=sys.stdout, stderr=sys.stderr)


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/bazel-mypy-integration/issues/70

> Last version of mypy/main.py that allowed positional arguments:
> https://github.com/python/mypy/blob/v0.971/mypy/main.py
> 
> Keyword arguments are required from 0.981 onwards (circle September 8, 2022):
> https://github.com/python/mypy/blob/v0.981/mypy/main.py