### PR TITLE
Handle mypy versions >= 0.981

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -4,4 +4,7 @@ import sys
 from mypy.main import main
 
 if __name__ == '__main__':
-    main(None, sys.stdout, sys.stderr)
+    if main.__version__ and '0.981' <= main.__version__:
+        main()
+    else:
+        main(None, sys.stdout, sys.stderr)


### PR DESCRIPTION
Fixes #68.

In https://github.com/python/mypy/pull/13399, which first appears in mypy release 0.981, the signature of `mypy.main.main()` changes to be incompatible with older versions of mypy. In this PR, we introspect the version and use a compatible function signature when it's greater than or equal to 0.981.