### PR TITLE
chore: fix CI by removing types

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1,7 +1,6 @@
 
 
 import sys
-from typing import Tuple
 from mypy.main import main
 from mypy.version import __version__
 
@@ -9,7 +8,7 @@ from mypy.version import __version__
 # - Release versions have the form "0.NNN".
 # - Dev versions have the form "0.NNN+dev" (PLUS sign to conform to PEP 440).
 # - For 1.0 we'll switch back to 1.2.3 form.
-def version_tuple(v: str) -> Tuple[int, ...]:
+def version_tuple(v):
     """Silly method of creating a comparable version object"""
     return tuple(map(int, (v.split("+")[0].split("."))))
 


### PR DESCRIPTION
Failure looks like ERROR: /home/runner/.cache/bazel/_bazel_runner/cc60d41263e182f209f2354ee347dd3d/external/mypy_integration_pip_deps/pypi__mypy_extensions/BUILD:5:11: no such package '@mypy_integration_pip_deps//pypi__typing': BUILD file not found in directory 'pypi__typing' of external repository @mypy_integration_pip_deps. Add a BUILD file to a directory to mark it as a package. and referenced by '@mypy_integration_pip_deps//pypi__mypy_extensions:pypi__mypy_extensions' 

And there's no funding to spend time fixing up this repo right now