### PR TITLE
Fix CI, add missing deps

### DIFF
--- a/current_mypy_version.txt
+++ b/current_mypy_version.txt
@@ -1,1 +1,4 @@
 mypy==0.790
+typing_extensions==4.4.0
+mypy_extensions==0.4.3
+tomli==2.0.1

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
 
+bazel clean --expunge
+
 echo "Running integration tests against repo's Bazel workspace..."
 # shellcheck source=/dev/null
 source "${test_dir}"/test_mypy.sh

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -1,1 +1,4 @@
 mypy==0.790
+typing_extensions==4.4.0
+mypy_extensions==0.4.3
+tomli==2.0.1


### PR DESCRIPTION
> `ERROR: /home/runner/.cache/bazel/_bazel_runner/cc60d41263e182f209f2354ee347dd3d/external/mypy_integration_pip_deps/pypi__mypy_extensions/BUILD:5:11: no such package '@mypy_integration_pip_deps//pypi__typing': BUILD file not found in directory 'pypi__typing' of external repository @mypy_integration_pip_deps. Add a BUILD file to a directory to mark it as a package. and referenced by '@mypy_integration_pip_deps//pypi__mypy_extensions:pypi__mypy_extensions'`