### PR TITLE
fix: Use PyInfo from rules-python

### DIFF
--- a/mypy.bzl
+++ b/mypy.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//lib:shell.bzl", "shell")
+load("@rules_python//python:defs.bzl", "PyInfo")
 load("//:rules.bzl", "MyPyStubsInfo")
 
 MyPyAspectInfo = provider(

--- a/rules.bzl
+++ b/rules.bzl
@@ -1,4 +1,7 @@
 "mypy_stubs rule"
+
+load("@rules_python//python:defs.bzl", "PyInfo")
+
 MyPyStubsInfo = provider(
     "TODO: docs",
     fields = {


### PR DESCRIPTION
Depending on bazel and configuration, `PyInfo` is either the starlark implementation or built-in, which makes the code more compatible.

```starlark
load("@aspect_rules_py//py:defs.bzl", "py_binary")

py_binary(
    name = "hello-world",
    ...
)

mypy_test(
    name = "hello-world-mypy",
    deps = [
        ":hello-world",
    ],
)
```

The above code fails because aspect_rule_py use `PyInfo` from `rules_python`.